### PR TITLE
[DOCS-10140] Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,11 @@
 * @carlosrodlop
 * @holywen
 * @ps-ssingh
+
+# Center of Excellence team as owners for files that require documentation review.
+
+*.md @cloudbees/team-docs-coe
+LICENSE @cloudbees/team-docs-coe
+outputs.tf @cloudbees/team-docs-coe
+variables.tf @cloudbees/team-docs-coe
+img/ @cloudbees/team-docs-coe


### PR DESCRIPTION
Added the CoE team as codeowners.

@carlosrodlop - do you mind granting write access to `team-docs-coe`, and then approving/merging this PR?