### PR TITLE
[OPS-19284] Revert "OPS-18175: Update to large-runners"

### DIFF
--- a/.github/workflows/md-link-checker.yml
+++ b/.github/workflows/md-link-checker.yml
@@ -9,8 +9,7 @@ on:
 jobs:
   check-links:
     name: MD_Check_Links
-    runs-on:
-      group: large-runners
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -28,8 +28,7 @@ jobs:
       # write permission is required for autolabeler
       # otherwise, read permission is required at least
       pull-requests: write
-    runs-on:
-      group: large-runners
+    runs-on: ubuntu-latest
     steps:
       # (Optional) GitHub Enterprise requires GHE_HOST variable set
       #- name: Set GHE_HOST

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -9,8 +9,7 @@ on:
 jobs:
   superlinter:
     name: Super_Linter
-    runs-on:
-      group: large-runners
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0

--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -9,8 +9,7 @@ on:
 jobs:
   docs:
     name: Terraform_Docs
-    runs-on:
-      group: large-runners
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -8,8 +8,7 @@ on:
 jobs:
   terraform:
     name: Terraform
-    runs-on:
-      group: large-runners
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
This reverts commit 9b0b02cd00e70d73ccd4869b6274964e583c96aa.

Public repos do not need to use large runners